### PR TITLE
docs: update class name for graph host

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,8 @@ Events are fired from the graph host. This is where we attach the event listener
 ```javascript
 // get the graph host
 // w/o shadow root
-const graphHost = document.getElementById('gc1').querySelector('.graph-host')
-// with shadow root: document.getElementById('gc1').shadowRoot.querySelector('.graph-host')
+const graphHost = document.getElementById('gc1').querySelector('.graph-controller__graph-host')
+// with shadow root: document.getElementById('gc1').shadowRoot.querySelector('.graph-controller__graph-host')
 
 // add event listener for right click on node
 graphHost.addEventListener('nodeclicked', function(e){


### PR DESCRIPTION
The class name seems to have changed:
 https://github.com/aig-hagen/aig_graph_component/blob/d96e5140aa205a7076f25c6e8a72044ab98f79eb/src/components/GraphComponent.vue#L1674